### PR TITLE
formatted CSS for general layouts - saved in _shared.css

### DIFF
--- a/app/assets/stylesheets/config/_fonts.scss
+++ b/app/assets/stylesheets/config/_fonts.scss
@@ -1,9 +1,9 @@
 // Import Google fonts
-@import url("https://fonts.googleapis.com/css?family=Open+Sans:400,300,700|Raleway:400,100,300,700,500");
+@import url("https://fonts.googleapis.com/css?family=Francois+One|Source+Sans+Pro:300,400,600,700");
 
 // Define fonts for body and headers
-$body-font: "Open Sans", "Helvetica", "sans-serif";
-$headers-font: "Raleway", "Helvetica", "sans-serif";
+$body-font: "Source Sans Pro", "Helvetica", "sans-serif";
+$headers-font: "Francois One", "Helvetica", "sans-serif";
 
 // To use a font file (.woff) uncomment following lines
 // @font-face {

--- a/app/assets/stylesheets/layouts/_index.scss
+++ b/app/assets/stylesheets/layouts/_index.scss
@@ -5,3 +5,4 @@
 // @import "map";
 
 @import "show";
+@import "shared";

--- a/app/views/vans/show.html.erb
+++ b/app/views/vans/show.html.erb
@@ -15,10 +15,10 @@
   <!-- Location -->
   <div class="details spacing">
     <!-- Geocoding on location? -->
-    <p><strong>LOCATION</strong></p>
+    <h5><strong>LOCATION</strong></h5>
     <p><%= @van.location %></p>
     <br>
-    <p><strong>DETAILS</strong></p>
+    <h5><strong>DETAILS</strong></h5>
     <ul-inline>
       <li><i class="fa fa-bus" aria-hidden="true"></i> <%= @van.make %> <%= @van.model %></li>
       <li><i class="fa fa-bed" aria-hidden="true"></i> <%= @van.bed %> bed(s) | <%= @van.sleep %> person(s)</li>


### PR DESCRIPTION
@ja5664 @agnesching19 @zuzannaglowacka I've created **_shared.scss** in the layouts folder for any shared CSS across different pages (e.g. font sizes, background etc.). I've updated the font families just to play around but if you're a fan of them then feel free to merge onto master.